### PR TITLE
Combine vertically adjacent region tiles into rectangles

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -1187,3 +1187,19 @@ void born_died(std::ostream & s, df::historical_figure *hf)
     }
     s << ")";
 }
+
+void render_map_coords(std::ostream &s, const df::coord2d_path &coords)
+{
+    s << "<svg width=\"100%\" style=\"max-width:500px;border:1px solid;float:right\" viewBox=\"0 0 " << world->world_data->world_width << " " << world->world_data->world_height << "\">";
+    for (size_t i = 0; i < coords.size(); i++)
+    {
+        int height = 1;
+        while (i + 1 < coords.size() && coords.x.at(i) == coords.x.at(i + 1) && coords.y.at(i) + 1 == coords.y.at(i + 1))
+        {
+            height++;
+            i++;
+        }
+        s << "<rect width=\"1\" height=\"" << height << "\" x=\"" << coords.x.at(i) << "\" y=\"" << (coords.y.at(i) - height + 1) << "\"></rect>";
+    }
+    s << "</svg>";
+}

--- a/helpers.h
+++ b/helpers.h
@@ -25,6 +25,7 @@ namespace df
     struct type;
     WEBLEGENDS_TYPES
 #undef WEBLEGENDS_TYPE
+    struct coord2d_path;
     struct creature_raw;
     struct entity_occasion_schedule_feature;
     struct history_event;
@@ -123,5 +124,7 @@ void pagination(std::ostream & s, const std::string & base, const std::string & 
 void spheres(std::ostream & s, df::historical_figure *hf);
 void year(std::ostream & s, int32_t year, int32_t tick);
 void born_died(std::ostream & s, df::historical_figure *hf);
+
+void render_map_coords(std::ostream &s, const df::coord2d_path &coords);
 
 #undef WEBLEGENDS_TYPES

--- a/render_layer.cpp
+++ b/render_layer.cpp
@@ -19,12 +19,7 @@ bool WebLegends::render_layer(std::ostream & s, int32_t id, int32_t page)
 
     simple_header(s, layer);
 
-    s << "<svg width=\"100%\" style=\"max-width:500px;border:1px solid;float:right\" viewBox=\"0 0 " << world->world_data->world_width << " " << world->world_data->world_height << "\">";
-    for (size_t i = 0; i < layer->region_coords.size(); i++)
-    {
-        s << "<rect width=\"1\" height=\"1\" x=\"" << layer->region_coords.x.at(i) << "\" y=\"" << layer->region_coords.y.at(i) << "\"></rect>";
-    }
-    s << "</svg>";
+    render_map_coords(s, layer->region_coords);
 
     s << "<p>";
     categorize(s, layer);

--- a/render_region.cpp
+++ b/render_region.cpp
@@ -19,12 +19,7 @@ bool WebLegends::render_region(std::ostream & s, int32_t id, int32_t page)
 
     simple_header(s, region);
 
-    s << "<svg width=\"100%\" style=\"max-width:500px;border:1px solid;float:right\" viewBox=\"0 0 " << world->world_data->world_width << " " << world->world_data->world_height << "\">";
-    for (size_t i = 0; i < region->region_coords.size(); i++)
-    {
-        s << "<rect width=\"1\" height=\"1\" x=\"" << region->region_coords.x.at(i) << "\" y=\"" << region->region_coords.y.at(i) << "\"></rect>";
-    }
-    s << "</svg>";
+    render_map_coords(s, region->region_coords);
 
     s << "<p>";
     categorize(s, region);


### PR DESCRIPTION
`region_coords` is sorted by x coordinates, then y coordinates. This can
significantly cut down the size of generated SVGs in larger worlds.